### PR TITLE
tf-idf.Rmd

### DIFF
--- a/tf-idf.Rmd
+++ b/tf-idf.Rmd
@@ -75,7 +75,7 @@ pipeline = Pipeline(stages=stages)
 pipeline.fit(df).transform(df).show(truncate=False)
 ```
 
-You may note that the first document has three terms, but only two term frequencies are obtained. This is because **the last category is NOT included by default**. This is similar to the **`StringIndexer()`**. The mismatch between the tf number and the terms number in document one indicates that there is a feature (term) mapped to the last column of the feature matrix.
+You may note that the first document has three distinct terms, but only two term frequencies are obtained. This apparent discrepancy is due to a **hashing collision**: both `spark` and `is` are getting hashed to `1`. The term frequency for index `1` in the first document is `4.0` corresponding to the three counts of `spark` and the one count of `is`. The likelihood of a hashing collision can be reduced by increasing the `numFeatures` parameter passed to the `HashingTF` function (the default for example is $2^18 = 262,144$). 
 
 ```
 +-------------------------------------------+------------------------------------------------+


### PR DESCRIPTION
The difference between the # terms in the HashingTf feature and the # distinct terms in the sentence is due to hashing collision, not the exclusion of the last term.